### PR TITLE
Increase buffer for API call payload

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ type ActionMessage struct {
 }
 
 func listen(connection *net.UDPConn, quit chan struct{}) {
-	buffer := make([]byte, 1024)
+	buffer := make([]byte, 4096)
 	n, _, err := 0, new(net.UDPAddr), error(nil)
 	var message ActionMessage
 	for err == nil {


### PR DESCRIPTION
`ApiCallAttempt` is a bit larger than `ApiCall`, and does not fit into 1024 bytes (mostly due to SessionToken field). Fixes https://github.com/princespaghetti/actionhero/issues/1